### PR TITLE
Fix quiz history recording and admin dashboard parameter

### DIFF
--- a/src/FingeringQuiz.jsx
+++ b/src/FingeringQuiz.jsx
@@ -53,17 +53,7 @@ function FingeringQuiz({ onBack }) {
     }
 
 
-    // Firebaseに記録
-    const user = auth.currentUser
-    if (user) {
-      addDoc(collection(db, 'users', user.uid, 'history'), {
-        quizType: 'fingering',
-        instrument,
-        level: lv,
-        score: null,
-        timestamp: serverTimestamp()
-      })
-    }
+    // 開始時点ではまだスコアが確定しないため記録しない
 
     setNoteList(range)
     setLevel(lv)
@@ -192,7 +182,7 @@ function FingeringQuiz({ onBack }) {
           quizType: 'fingering',
           instrument,
           level: level,
-          score: null,
+          score: score + (correct ? 1 : 0),
           timestamp: serverTimestamp()
         })
       }

--- a/src/components/AdminPage.jsx
+++ b/src/components/AdminPage.jsx
@@ -9,7 +9,7 @@ export default function AdminPage() {
     <div>
       {selectedUid ? (
         <Dashboard
-          selectedUid={selectedUid}
+          userId={selectedUid}
           onBack={() => setSelectedUid(null)} // 戻るときにユーザー選択をクリア
         />
       ) : (


### PR DESCRIPTION
## Summary
- fix AdminPage to pass correct prop name to Dashboard
- record final score to Firestore in FingeringQuiz
- remove premature history entry when quiz starts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840056a1990832b8dd367f2829111be