### PR TITLE
Allow admins to edit any profile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import NoteNameQuiz from './NoteNameQuiz'
 import FingeringQuiz from './FingeringQuiz'
 import UsersList from './components/UsersList'
 import Dashboard from './components/Dashboard'
+import Profile from './Profile'
 
 /**
  * App コンポーネント
@@ -13,6 +14,8 @@ import Dashboard from './components/Dashboard'
 function App({ isAdmin }) {
   const [mode, setMode] = useState('menu')
   const [selectedUid, setSelectedUid] = useState(null)
+  const [editUid, setEditUid] = useState(null)
+  const [profileBack, setProfileBack] = useState('menu')
 
   // ログアウト処理
   const handleLogout = async () => {
@@ -33,6 +36,20 @@ function App({ isAdmin }) {
     return <FingeringQuiz onBack={() => setMode('menu')} />
   }
 
+  // プロフィール編集
+  if (mode === 'profile') {
+    return (
+      <Profile
+        uid={editUid}
+        isAdmin={isAdmin}
+        onBack={() => {
+          setEditUid(null)
+          setMode(profileBack)
+        }}
+      />
+    )
+  }
+
   // 管理：ユーザー一覧
   if (mode === 'usersList') {
     return (
@@ -40,6 +57,11 @@ function App({ isAdmin }) {
         onSelect={(uid) => {
           setSelectedUid(uid)
           setMode('userHistory')
+        }}
+        onEditProfile={(uid) => {
+          setEditUid(uid)
+          setProfileBack('usersList')
+          setMode('profile')
         }}
         onBack={() => setMode('menu')}
       />
@@ -59,6 +81,15 @@ function App({ isAdmin }) {
         <button onClick={() => setMode('note')}>音名クイズ</button>
         <button onClick={() => setMode('fingering')}>運指クイズ</button>
         {isAdmin && <button onClick={() => setMode('usersList')}>ユーザー管理</button>}
+        <button
+          onClick={() => {
+            setEditUid(null)
+            setProfileBack('menu')
+            setMode('profile')
+          }}
+        >
+          プロフィール
+        </button>
         <button onClick={handleLogout}>ログアウト</button>
       </div>
     </div>

--- a/src/Profile.jsx
+++ b/src/Profile.jsx
@@ -1,0 +1,67 @@
+import { useState, useEffect } from 'react'
+import { auth, db } from './firebase'
+import { updateProfile } from 'firebase/auth'
+import { doc, setDoc, getDoc } from 'firebase/firestore'
+
+function Profile({ onBack, uid, isAdmin }) {
+  const current = auth.currentUser
+  const targetUid = isAdmin && uid ? uid : current?.uid
+  const isSelf = targetUid === current?.uid
+  const [displayName, setDisplayName] = useState('')
+
+  useEffect(() => {
+    if (!targetUid) return
+    async function fetchName() {
+      if (isSelf) {
+        setDisplayName(current?.displayName || '')
+      } else {
+        const snap = await getDoc(doc(db, 'users', targetUid))
+        setDisplayName(snap.exists() ? snap.data().displayName || '' : '')
+      }
+    }
+    fetchName()
+  }, [targetUid, isSelf, current])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!targetUid) return
+    try {
+      if (isSelf && current) {
+        await updateProfile(current, { displayName })
+      }
+      await setDoc(doc(db, 'users', targetUid), { displayName }, { merge: true })
+      alert('プロフィールを更新しました')
+      onBack()
+    } catch (err) {
+      console.error(err)
+      alert('更新に失敗しました')
+    }
+  }
+
+  return (
+    <div style={{ textAlign: 'center', marginTop: '50px' }}>
+      <h2>プロフィール編集</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            type="text"
+            value={displayName}
+            placeholder="表示名"
+            onChange={(e) => setDisplayName(e.target.value)}
+            style={{ padding: '8px', width: '250px' }}
+          />
+        </div>
+        <div style={{ marginTop: '15px' }}>
+          <button type="submit" style={{ padding: '8px 16px', marginRight: '10px' }}>
+            保存
+          </button>
+          <button type="button" onClick={onBack} style={{ padding: '8px 16px' }}>
+            戻る
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default Profile

--- a/src/components/UsersList.jsx
+++ b/src/components/UsersList.jsx
@@ -6,7 +6,7 @@ import { db } from '../firebase'
  * ユーザー一覧コンポーネント
  * 管理者向けに全ユーザーを表示し、最後の問題取り組み時間・内容・成績でソート表示
  */
-export default function UsersList({ onSelect, onBack }) {
+export default function UsersList({ onSelect, onBack, onEditProfile }) {
   const [users, setUsers] = useState([])
   const [loading, setLoading] = useState(true)
   const [sortField, setSortField] = useState('lastActivity')
@@ -97,6 +97,7 @@ export default function UsersList({ onSelect, onBack }) {
             <th style={{ border: '1px solid #ccc', padding: 8 }}>音名クイズ</th>
             <th style={{ border: '1px solid #ccc', padding: 8 }}>運指クイズ</th>
             <th style={{ border: '1px solid #ccc', padding: 8 }}>詳細</th>
+            <th style={{ border: '1px solid #ccc', padding: 8 }}>編集</th>
           </tr>
         </thead>
         <tbody>
@@ -122,6 +123,9 @@ export default function UsersList({ onSelect, onBack }) {
               <td style={{ border: '1px solid #ccc', padding: 8 }}>{u.fingeringSummary}</td>
               <td style={{ border: '1px solid #ccc', padding: 8 }}>
                 <button onClick={() => onSelect(u.uid)}>履歴を見る</button>
+              </td>
+              <td style={{ border: '1px solid #ccc', padding: 8 }}>
+                <button onClick={() => onEditProfile(u.uid)}>編集</button>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- make `Profile` accept a UID and allow admins to edit other users
- update main menu and user list to pass UID when editing
- add edit button in user list
- remember whether profile edit came from menu or users list and return accordingly

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684005c070b4832b95e561d770e45b28