### PR TITLE
Fix quiz history recording and admin dashboard parameter

### DIFF
--- a/src/FingeringQuiz.jsx
+++ b/src/FingeringQuiz.jsx
@@ -53,17 +53,7 @@ function FingeringQuiz({ onBack }) {
     }
 
 
-    // Firebaseに記録
-    const user = auth.currentUser
-    if (user) {
-      addDoc(collection(db, 'users', user.uid, 'history'), {
-        quizType: 'fingering',
-        instrument,
-        level: lv,
-        score: null,
-        timestamp: serverTimestamp()
-      })
-    }
+    // 開始時点ではまだスコアが確定しないため記録しない
 
     setNoteList(range)
     setLevel(lv)
@@ -192,7 +182,7 @@ function FingeringQuiz({ onBack }) {
           quizType: 'fingering',
           instrument,
           level: level,
-          score: null,
+          score: score + (correct ? 1 : 0),
           timestamp: serverTimestamp()
         })
       }

--- a/src/NoteNameQuiz.jsx
+++ b/src/NoteNameQuiz.jsx
@@ -4,8 +4,7 @@ import { Renderer } from 'vexflow'
 import { Stave, StaveNote, Formatter, Accidental } from 'vexflow'
 import { TREBLE_NOTE_RANGES, BASS_NOTE_RANGES, BASS_TUBA_NOTE_RANGES } from './data/noteNameRanges'
 
-import { doc, collection, addDoc, serverTimestamp } from 'firebase/firestore'
-import { auth, db } from './firebase'
+// Firebase は recordHistory 内で使用
 
 
 function NoteNameQuiz({ onBack }) {
@@ -113,26 +112,11 @@ function NoteNameQuiz({ onBack }) {
     } else {
        const finalScore = score + (correct ? 1 : 0)
        setMessage(`🎉 終了！スコア：${finalScore} / 20`)
-      // Firestore に記録
-       recordHistory('note', level, finalScore, 10).catch(console.error)     
+      // Firestore に記録（全20問）
+      recordHistory('note', level, finalScore, 20).catch(console.error)
     }
 
-    // 終了処理内（例: スコア表示直前）で追加
-    if (questionNumber === 19) {
-     (async () => {
-       const user = auth.currentUser
-        if (user) {
-          await addDoc(collection(doc(db, 'users', user.uid), 'history'), {
-          quizType: 'notename',
-          clef,
-          bassMode: bassMode || null,
-          level,
-          score: score + (correct ? 1 : 0),
-          timestamp: serverTimestamp()
-           })
-        }
-      })()
-    }
+    // フィニッシュ時のみ記録するため上記以外では何もしない
 
   }
 

--- a/src/components/AdminPage.jsx
+++ b/src/components/AdminPage.jsx
@@ -9,7 +9,7 @@ export default function AdminPage() {
     <div>
       {selectedUid ? (
         <Dashboard
-          selectedUid={selectedUid}
+          userId={selectedUid}
           onBack={() => setSelectedUid(null)} // 戻るときにユーザー選択をクリア
         />
       ) : (


### PR DESCRIPTION
## Summary
- fix AdminPage to pass correct prop name to Dashboard
- record final score to Firestore in FingeringQuiz
- remove premature history entry when quiz starts
- avoid duplicate note history entries and store full question total

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840056a1990832b8dd367f2829111be